### PR TITLE
Fix for missing parent param

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 
 This [Eleventy](https://www.11ty.dev/) plugin automatically embeds responsive Twitch videos from URLs in Markdown files.
 
-- ⚡️ [Installation](#%EF%B8%8F-installation)
-- 🛠 [Usage](#-usage)
-- ⚙️ [Settings](#%EF%B8%8F-settings)
-- ⚠️ [Notes and caveats](#%EF%B8%8F-notes-and-caveats)
+- ⚡️ [Installation](#installation)
+- 🛠 [Usage](#usage)
+- ⚙️ [Settings](#settings)
+- ⚠️ [Notes and caveats](#notes-and-caveats)
 
 ---
+<span id="installation"></span>
 
 ## ⚡️ Installation
 
@@ -28,9 +29,19 @@ Then add it to your [Eleventy config](https://www.11ty.dev/docs/config/) file:
 const embedTwitch = require("eleventy-plugin-embed-twitch");
 
 module.exports = function(eleventyConfig) {
-  eleventyConfig.addPlugin(embedTwitch);
+  eleventyConfig.addPlugin(embedTwitch, {
+    /**
+     * `parent` is now a REQUIRED option. It MUST comply with these specs (set by Twitch):
+     * - Must be a text string
+     * - Must be the domain where the embed will be shown, without the protocol
+     * - Reference: https://dev.twitch.tv/docs/embed/video-and-clips#non-interactive-inline-frames-for-live-streams-and-vods
+     */
+    parent: "example.com"
+  });
 };
 ```
+
+<span id="usage"></span>
 
 ## 🛠 Usage
 
@@ -50,13 +61,17 @@ Maecenas non velit nibh. Aenean eu justo et odio commodo ornare. In scelerisque 
 
 ![Twitch streamer Vixella playing Animal Crossing](https://user-images.githubusercontent.com/547470/80289103-77f21d00-870a-11ea-85d8-69fa67c449bd.png)
 
+<span id="settings"></span>
+
 ## ⚙️ Settings
 
 You can configure the plugin to change its behavior by passing an options object to the `addPlugin` function:
 
 ```javascript
 eleventyConfig.addPlugin(embedTwitch, {
-  // edit options here
+  // `parent` value is required!
+  parent: "example.com",
+  //...set additional options here
 });
 ```
 
@@ -75,6 +90,11 @@ Edit any of the default values in this options object to override the plugin beh
   // Default class that gets applied to the wrapper <div>.
   // Substitute your preferred string to target embeds with CSS.
   embedClass: 'eleventy-plugin-embed-twitch',
+  // REQUIRED
+  // @since 2.0.0
+  // Default value is empty, which will produce a console error when building your site.
+  // Set this to your website’s domain, such as "example.com" or "subdomain.example.com".
+  parent: ""
 }
 ```
 
@@ -98,6 +118,8 @@ https://www.twitch.tv/videos/597008599
 ```
 
 If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-twitch/issues/new)!
+
+<span id="notes-and-caveats"></span>
 
 ## ⚠️ Notes and caveats
 

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,4 +1,18 @@
+const chalk = require('chalk');
+
 module.exports = function(media, options) {
+
+  /**
+   * If the user hasn't set the "parent" value, print an error to the console
+   * Default value is an empty string instead of null or undefined, to make it
+   * more intuitively obvious to the user that it needs to be a string.
+   * We coerce the empty string to falsy with the triple-bang trick.
+   */
+  if ( !!!options.parent ) {
+    console.error(`⚠️  ${ chalk.red('Error embedding Twitch video') }
+  Eleventy plugin ${chalk.cyan('eleventy-plugin-embed-twitch')} requires a \`parent\` option to be set.
+  🔗  See ${chalk.cyan.underline('https://bit.ly/11ty-plugin-twitch-parent-error')} for details.`);
+}
   
   // Build the string, using config data as we go
   // id based on channel or video id
@@ -20,10 +34,14 @@ module.exports = function(media, options) {
   // TODO: more granular autoplay controls
   if ( media.type === 'channel' ) {
     out += `channel=${media.id}`;
-    out += options.autoplayChannels ? `&autoplay=true"` : `&autoplay=false"`;
+    out += options.autoplayChannels ? `&autoplay=true` : `&autoplay=false`;
+    out += `&parent=${options.parent}`;
+    out += `"`;
   }
   if ( media.type === 'video' ){
-    out += `video=${media.id}&autoplay=false"`;
+    out += `video=${media.id}&autoplay=false`;
+    out += `&parent=${options.parent}`;
+    out += `"`;
   }
   out += ` allow="${options.allowAttrs}" allowfullscreen`
   out += '></iframe></div>';

--- a/lib/pluginDefaults.js
+++ b/lib/pluginDefaults.js
@@ -2,4 +2,5 @@ module.exports = {
   allowAttrs: 'autoplay, fullscreen',
   autoplayChannels: true,
   embedClass: 'eleventy-plugin-embed-twitch',
+  parent: "",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -502,9 +502,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "bugs": "https://github.com/gfscott/eleventy-plugin-embed-twitch/issues",
   "devDependencies": {
-    "ava": "^3.8.2"
+    "ava": "^3.8.2",
+    "chalk": "^4.1.0"
   }
 }


### PR DESCRIPTION
Close #3 

I finally investigated this error and discovered that Twitch [implemented a new requirement](https://dev.twitch.tv/docs/change-log) for embeds to specify a `parent` param in the iframe `src` URL. "Parent" [must be the domain of the page](https://dev.twitch.tv/docs/embed/video-and-clips/#non-interactive-inline-frames-for-live-streams-and-vods) where the embed will appear (which is a very 😑  design choice, but hey, it's their platform).

This PR implements a new required `parent` option which is empty by default. The plugin will now check whether `parent` has been set, and outputs a fairly noisy console message if it hasn't. I've also added [a wiki page](https://github.com/gfscott/eleventy-plugin-embed-twitch/wiki/Error:-Twitch-embed-requires-a-%60parent%60-option-to-be-set) to assist users who see that error.