### PR TITLE
Add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,19 @@
+# Ignore gitignore (meta!)
+.gitignore
+
+# Ignore tests
+test.js
+test/
+
+# Ignore CI config
+.travis.yml
+
+# Ignore coverage files is redundant with gitignore, but just in case
+.nyc_output
+coverage/
+
+# Ignore editor style stuff
+.editorconfig
+
+# Ignore code of conduct
+CODE_OF_CONDUCT.md


### PR DESCRIPTION
Adding an .npmignore file to keep package size lean, given that tests will be growing soon.